### PR TITLE
fixed add medication button on ios

### DIFF
--- a/screens/MedicationListScreen.js
+++ b/screens/MedicationListScreen.js
@@ -93,7 +93,9 @@ const MedicationListScreen = ({navigation}) => {
                         </TouchableOpacity>
                     )}/>
                 )}
-                <Button title="ADD NEW MEDICATION" color='#42C86A' onPress={()=>{navigation.navigate('AddMedication')}}/>
+                <View style={styles.addMedicationButton}>
+                    <Button title="ADD NEW MEDICATION" color='#42C86A' onPress={()=>{navigation.navigate('AddMedication')}}/>
+                </View>
             </Animatable.View>
         </KeyboardAvoidingView>
     )
@@ -139,6 +141,11 @@ const styles = StyleSheet.create({
     searchButton:{
         right: 5
     },
+    addMedicationButton: {
+        position: 'absolute', 
+        top: screenHeight * 0.65, 
+        alignSelf: 'center'
+    }, 
 });
 
 export default MedicationListScreen;


### PR DESCRIPTION
- Add medication button should show on iOS under medication list
fix: not ideal but, I used absolute positioning. 